### PR TITLE
feat(utils): allow magnet links

### DIFF
--- a/packages/internal/utils/src/html.test.ts
+++ b/packages/internal/utils/src/html.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+
+import { parseHtml } from "./html"
+
+describe("parseHtml", () => {
+  it("should preserve magnet links", () => {
+    const { hastTree } = parseHtml('<a href="magnet:?xt=urn:btih:123">magnet</a>')
+    const root: any = hastTree
+    const anchor = root.children[0]
+    expect(anchor.tagName).toBe("a")
+    expect(anchor.properties.href).toBe("magnet:?xt=urn:btih:123")
+  })
+})

--- a/packages/internal/utils/src/html.ts
+++ b/packages/internal/utils/src/html.ts
@@ -50,6 +50,10 @@ export const parseHtml = (content: string, options?: ParseHtmlOptions) => {
 
   const rehypeSchema: Schema = { ...defaultSchema }
   rehypeSchema.tagNames = [...rehypeSchema.tagNames!, "math"]
+  rehypeSchema.protocols = {
+    ...rehypeSchema.protocols,
+    href: [...((rehypeSchema.protocols?.href as string[]) || []), "magnet"],
+  }
 
   if (noMedia) {
     rehypeSchema.tagNames = rehypeSchema.tagNames?.filter(


### PR DESCRIPTION
## Summary
- allow magnet links in sanitized HTML
- add test covering magnet href support

## Testing
- `pnpm --filter @follow/utils test`
- `pnpm exec eslint packages/internal/utils/src/html.ts packages/internal/utils/src/html.test.ts` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './defaultConfig' is not defined by "exports" in tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_e_68be98a1c808832082a7d897250c6ddf